### PR TITLE
Misc. typos

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,5 +24,5 @@ mock ; python_version < '3'
 # pywin32 & pywinauto>=0.4.0 are Win32 UI test dependencies that have been
 # excluded from this file as they are quite expensive to install, and they
 # are not useful on the Appveyor Win32 builds since the relevant UI tests
-# also require accessing the menu of the console window, which doesnt exist
+# also require accessing the menu of the console window, which doesn't exist
 # in the Appveyor environment.

--- a/pywikibot/README.rst
+++ b/pywikibot/README.rst
@@ -48,7 +48,7 @@ in your current directory. It asks for the family and language code you are
 working on and at least for the bot's user name; this will be used to identify
 you when the robot is making changes, in case you are not logged in. You may
 choose to create a small or extended version of the config file with further
-informations. Other variables that can be set in the configuration file, please
+information. Other variables that can be set in the configuration file, please
 check config.py for ideas.
 
 

--- a/pywikibot/__init__.py
+++ b/pywikibot/__init__.py
@@ -188,7 +188,7 @@ class Timestamp(datetime.datetime):
         @return: Timestamp object
         @rtype: Timestamp
         """
-        # If inadvertantly passed a Timestamp object, use replace()
+        # If inadvertently passed a Timestamp object, use replace()
         # to create a clone.
         if isinstance(ts, cls):
             return ts.clone()
@@ -197,7 +197,7 @@ class Timestamp(datetime.datetime):
     @classmethod
     def fromtimestampformat(cls, ts):
         """Convert a MediaWiki internal timestamp to a Timestamp object."""
-        # If inadvertantly passed a Timestamp object, use replace()
+        # If inadvertently passed a Timestamp object, use replace()
         # to create a clone.
         if isinstance(ts, cls):
             return ts.clone()
@@ -237,7 +237,7 @@ class Timestamp(datetime.datetime):
             return newdt
 
     def __sub__(self, other):
-        """Perform substraction, returning a Timestamp instead of datetime."""
+        """Perform subtraction, returning a Timestamp instead of datetime."""
         newdt = super(Timestamp, self).__sub__(other)
         if isinstance(newdt, datetime.datetime):
             return Timestamp(newdt.year, newdt.month, newdt.day, newdt.hour,
@@ -1246,7 +1246,7 @@ def Site(code=None, fam=None, user=None, sysop=None, interface=None, url=None):
     sysop = sysop or code_to_sysop.get(code) or code_to_sysop.get('*')
 
     if not isinstance(interface, type):
-        # If it isnt a class, assume it is a string
+        # If it isn't a class, assume it is a string
         try:
             tmp = __import__('pywikibot.site', fromlist=[interface])
         except ImportError:

--- a/pywikibot/bot.py
+++ b/pywikibot/bot.py
@@ -124,7 +124,7 @@ from pywikibot.tools._logging import (
 from pywikibot.tools.formatter import color_format
 
 
-# Note: all output goes thru python std library "logging" module
+# Note: all output goes through python std library "logging" module
 _logger = 'bot'
 
 if not PY2:
@@ -1448,7 +1448,7 @@ class BaseBot(OptionHandler):
                                   % self.__class__.__name__)
 
     def setup(self):
-        """Some inital setup before run operation starts.
+        """Some initial setup before run operation starts.
 
         This can be used for reading huge parts from life wiki or file
         operation which is more than just initialize the instance.
@@ -1536,7 +1536,7 @@ class Bot(BaseBot):
     """
 
     def __init__(self, site=None, **kwargs):
-        """Create a Bot instance and initalize cached sites."""
+        """Create a Bot instance and initialize cached sites."""
         # TODO: add warning if site is specified and generator
         # contains pages from a different site.
         # Do not set self._site to None if we already have it
@@ -1587,7 +1587,7 @@ class Bot(BaseBot):
         # self.site causes bugs in subclasses.
         # If the subclass has set self.site before run(), it may be that the
         # bot processes pages on sites other than self.site, and therefore
-        # this method cant alter self.site. To use this functionality, don't
+        # this method can't alter self.site. To use this functionality, don't
         # set self.site in __init__, and use page.site in treat().
         self._auto_update_site = not self._site
         if not self._auto_update_site:

--- a/pywikibot/bot_choice.py
+++ b/pywikibot/bot_choice.py
@@ -102,7 +102,7 @@ class OutputOption(Option):
         self.output()
 
     def output(self):
-        """Output a string when selected and possibily before the question."""
+        """Output a string when selected and possibly before the question."""
         raise NotImplementedError()
 
 
@@ -181,7 +181,7 @@ class NestedOption(OutputOption, StandardOption):
         return super(NestedOption, self).format(default=default)
 
     def handled(self, value):
-        """Return itself if it applies or the appling sub option."""
+        """Return itself if it applies or the applying sub option."""
         for option in self.options:
             handled = option.handled(value)
             if handled is not None:

--- a/pywikibot/comms/http.py
+++ b/pywikibot/comms/http.py
@@ -208,7 +208,7 @@ def user_agent(site=None, format_string=None):
         script_comments.append(str(site))
 
         # TODO: there are several ways of identifying a user, and username
-        # is not the best for a HTTP header if the username isnt ASCII.
+        # is not the best for a HTTP header if the username isn't ASCII.
         if site.username():
             username = user_agent_username(site.username())
             script_comments.append(

--- a/pywikibot/config2.py
+++ b/pywikibot/config2.py
@@ -244,7 +244,7 @@ available_ssl_project = []
 # the permissions given to a bot. When using BotPasswords, each instance gets
 # keys. This combination can only access the API, not the normal web interface.
 # See https://www.mediawiki.org/wiki/Manual:Pywikibot/BotPasswords to know how
-# use them. In this case, the password file should contein a BotPassword object
+# use them. In this case, the password file should contain a BotPassword object
 # in the following format:
 # (username, BotPassword(botname, botpassword))
 password_file = None
@@ -983,7 +983,7 @@ def _win32_extension_command(extension):
         cmd = _cmd
         if cmd.find('%1'):
             cmd = cmd[:cmd.find('%1')]
-            # Remove any trailing characher, which should be a quote or space
+            # Remove any trailing character, which should be a quote or space
             # and then remove all whitespace.
             return cmd[:-1].strip()
     except WindowsError as e:
@@ -1151,7 +1151,7 @@ if OSWIN32 and editor:
         warning(
             'The editor path contains probably invalid escaped '
             'characters. Make sure to use a raw-string (r"..." or '
-            "r'...'), forward slashs as a path delimiter or to escape the "
+            "r'...'), forward slashes as a path delimiter or to escape the "
             'normal path delimiter.')
 
 if userinterface_lang is None:

--- a/pywikibot/data/api.py
+++ b/pywikibot/data/api.py
@@ -245,7 +245,7 @@ class ParamInfo(Container):
             if self.modules_only_mode:
                 self.paraminfo_keys = frozenset(['modules'])
 
-        # v1.18 and earlier paraminfo doesnt include modules; must use 'query'
+        # v1.18 and earlier paraminfo doesn't include modules; must use 'query'
         # Assume that by v1.26, it will be desirable to prefetch 'query'
         if mw_ver > '1.26' or mw_ver < '1.19':
             self.preloaded_modules |= {'query'}
@@ -282,7 +282,7 @@ class ParamInfo(Container):
 
     def _emulate_pageset(self):
         """Emulate the pageset module, which existed in MW 1.15-1.24."""
-        # pageset isnt a module in the new system, so it is emulated, with
+        # pageset isn't a module in the new system, so it is emulated, with
         # the paraminfo from the query module.
         assert('query' in self._paraminfo)
 
@@ -679,7 +679,7 @@ class ParamInfo(Container):
         @rtype: dict or None
         """
         # TODO: the 'description' field of each parameter is not in the default
-        # output of v1.25, and cant removed from previous API versions.
+        # output of v1.25, and can't removed from previous API versions.
         # There should be an option to remove this verbose data from the cached
         # version, for earlier versions of the API, and/or extract any useful
         # data and discard the entire received paraminfo structure. There are
@@ -703,7 +703,7 @@ class ParamInfo(Container):
 
         assert(len(param_data) == 1)
         param_data = param_data[0]
-        # pre 1.14 doesnt provide limit attribute on parameters
+        # pre 1.14 doesn't provide limit attribute on parameters
         if 'multi' in param_data and 'limit' not in param_data:
             param_data['limit'] = self._limit
         return param_data
@@ -1438,7 +1438,7 @@ class Request(MutableMapping):
         return iter(self._params.items())
 
     def items(self):
-        """Return a list of tuples containg the parameters in any order."""
+        """Return a list of tuples containing the parameters in any order."""
         return list(self._params.items())
 
     @property
@@ -2168,7 +2168,7 @@ class CachedRequest(Request):
                 'name' in self.site._userinfo:
             # This uses the format of Page.__repr__, without performing
             # config.console_encoding as done by Page.__repr__.
-            # The returned value cant be encoded to anything other than
+            # The returned value can't be encoded to anything other than
             # ascii otherwise it creates an exception when _create_file_name()
             # tries to encode it as utf-8.
             user_key = 'User(User:%s)' % self.site._userinfo['name']
@@ -2184,7 +2184,7 @@ class CachedRequest(Request):
         """
         Return a unique ascii identifier for the cache entry.
 
-        @rtype: str (hexademical; i.e. characters 0-9 and a-f only)
+        @rtype: str (hexadecimal; i.e. characters 0-9 and a-f only)
         """
         return hashlib.sha256(
             self._uniquedescriptionstr().encode('utf-8')

--- a/pywikibot/data/mysql.py
+++ b/pywikibot/data/mysql.py
@@ -46,7 +46,7 @@ def mysql_query(query, params=None, dbname=None, verbose=None):
 
     @param query: MySQL query to execute
     @type query: str (unicode in py2)
-    @param params: input parametes for the query, if needed
+    @param params: input parameters for the query, if needed
         if list or tuple, %s shall be used as placeholder in the query string.
         if a dict, %(key)s shall be used as placeholder in the query string.
     @type params: tuple, list or dict of str (unicode in py2)

--- a/pywikibot/date.py
+++ b/pywikibot/date.py
@@ -53,7 +53,7 @@ def multi(value, tuplst):
 
     For example: 1st century, 2nd century, etc.
 
-    The tuplst is a list of tupples. Each tupple must contain two functions:
+    The tuplst is a list of tuples. Each tuple must contain two functions:
     first to encode/decode a single value (e.g. simpleInt), second is a
     predicate function with an integer parameter that returns true or false.
     When the 2nd function evaluates to true, the 1st function is used.
@@ -329,7 +329,7 @@ _digitDecoders = {
     '%': '%',
     # %d is a decimal
     'd': (_decimalDigits, unicode, int),
-    # %R is a roman numeral. This allows for only the simpliest linear
+    # %R is a roman numeral. This allows for only the simplest linear
     # conversions based on a list of numbers
     'R': ('IVX', intToRomanNum, romanNumToInt),
     # %K is a number in KN::
@@ -511,7 +511,7 @@ def MakeParameter(decoder, param):
 # All years/decades/centuries/millenniums are designed in such a way
 # as to allow for easy date to string and string to date conversion.
 # For example, using any map with either an integer or a string will produce
-# its oposite value:
+# its opposite value:
 #        Usage scenarios:
 #            formats['DecadeAD']['en'](1980) => '1980s'
 #            formats['DecadeAD']['en']('1980s') => 1980
@@ -1953,7 +1953,7 @@ def makeMonthList(pattern):
 def makeMonthNamedList(lang, pattern, makeUpperCase=None):
     """Create a list of 12 elements based on the name of the month.
 
-    The language-dependent month name is used as a formating argument to the
+    The language-dependent month name is used as a formatting argument to the
     pattern. The pattern must be have one %s that will be replaced by the
     localized month name.
     Use %%d for any other parameters that should be preserved.
@@ -2282,7 +2282,7 @@ def getNumberOfDaysInMonth(month):
     """
     Return the maximum number of days in a given month, 1 being January, etc.
 
-    For February alway 29 will be given, even it is not a leap year.
+    For February always 29 will be given, even it is not a leap year.
     """
     # use year 2000 which is a leap year
     return calendar.monthrange(2000, month)[1]

--- a/pywikibot/epydoc.cfg
+++ b/pywikibot/epydoc.cfg
@@ -33,7 +33,7 @@ url: https://www.mediawiki.org/wiki/Manual:Pywikibot
 frames: yes
 
 # private
-#   Whether or not to inclue private variables.  (Even if included,
+#   Whether or not to include private variables.  (Even if included,
 #   private variables will be hidden by default.)
 private: yes
 
@@ -43,7 +43,7 @@ imports: yes
 
 # verbosity
 #   An integer indicating how verbose epydoc should be.  The default
-#   value is 0; negative values will supress warnings and errors;
+#   value is 0; negative values will suppress warnings and errors;
 #   positive values will give more verbose output.
 verbosity: 0
 

--- a/pywikibot/exceptions.py
+++ b/pywikibot/exceptions.py
@@ -73,7 +73,7 @@ be aware of its status.
   - tools._NotImplementedWarning: do not use
   - NotImplementedWarning: functionality not implemented
 
-UserWarning: warnings targetted at users
+UserWarning: warnings targeted at users
 
   - config2._ConfigurationDeprecationWarning: user configuration file problems
   - login._PasswordFileWarning: password file problems

--- a/pywikibot/family.py
+++ b/pywikibot/family.py
@@ -65,8 +65,8 @@ class Family(object):
             cls.__init__ = deprecated(cls.__dict__['__init__'])
 
             # Invoke initializer immediately and make initializer no-op.
-            # This is to avoid repeated initializer invokation on repeated
-            # invokations of the metaclass's __call__.
+            # This is to avoid repeated initializer invocation on repeated
+            # invocations of the metaclass's __call__.
             cls.instance.__init__()
             cls.__init__ = lambda self: None  # no-op
 
@@ -1621,7 +1621,7 @@ class WikimediaFamily(Family):
         + wikimedia_org_other_families
     )
 
-    # CentralAuth cross avaliable projects.
+    # CentralAuth cross available projects.
     cross_projects = set(
         multi_language_content_families
         + wikimedia_org_content_families

--- a/pywikibot/fixes.py
+++ b/pywikibot/fixes.py
@@ -404,15 +404,15 @@ fixes = {
             # superfluous word "number"
             (r'ISBN(?: [Nn]umber| [Nn]o\.?|-Nummer|-Nr\.):? (\d+)',
              r'ISBN \1'),
-            # Space, minus, dot, hypen, en dash, em dash, etc. instead of
+            # Space, minus, dot, hyphen, en dash, em dash, etc. instead of
             # hyphen-minus as separator,
             # or spaces between digits and separators.
             # Note that these regular expressions also match valid ISBNs, but
             # these won't be changed.
             # These two regexes don't verify that the ISBN is of a valid format
-            # but just change separators into normal hypens. The isbn script
+            # but just change separators into normal hyphens. The isbn script
             # does checks and similar but does only match ISBNs with digits and
-            # hypens (and optionally a X/x at the end).
+            # hyphens (and optionally a X/x at the end).
             (r'ISBN (978|979) *[\- −.‐-―] *(\d+) *[\- −.‐-―] *(\d+) '
              r'*[\- −.‐-―] *(\d+) *[\- −.‐-―] *(\d)(?!\d)',
              r'ISBN \1-\2-\3-\4-\5'),  # ISBN-13

--- a/pywikibot/logentries.py
+++ b/pywikibot/logentries.py
@@ -129,7 +129,7 @@ class LogEntry(object):
         return self._page
 
     def type(self):
-        """The type of thie logentry."""
+        """The type of this logentry."""
         return self.data['type']
 
     def action(self):

--- a/pywikibot/login.py
+++ b/pywikibot/login.py
@@ -127,7 +127,7 @@ usernames['%(fam_name)s']['%(wiki_code)s'] = 'myUsername'"""
         """
         Check that the username exists on the site.
 
-        @raises NoUsername: Username doesnt exist in user list.
+        @raises NoUsername: Username doesn't exist in user list.
         """
         # convert any Special:BotPassword usernames to main account equivalent
         main_username = self.username

--- a/pywikibot/page.py
+++ b/pywikibot/page.py
@@ -951,7 +951,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
         Return True if this is a disambiguation page, False otherwise.
 
         By default, it uses the the Disambiguator extension's result. The
-        identification relies on the presense of the __DISAMBIG__ magic word
+        identification relies on the presence of the __DISAMBIG__ magic word
         which may also be transcluded.
 
         If the Disambiguator extension isn't activated for the given site,
@@ -1827,7 +1827,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
     @deprecated_args(limit='total')
     def getLatestEditors(self, total=1):
         """
-        Get a list of revision informations of the last total edits.
+        Get a list of revision information of the last total edits.
 
         DEPRECATED: Use Page.revisions.
 

--- a/pywikibot/pagegenerators.py
+++ b/pywikibot/pagegenerators.py
@@ -663,11 +663,11 @@ class GeneratorFactory(object):
             compatibility, this can also be the total amount of pages
             that should be returned. It is taken as 'total' if the value does
             not have 8 digits.
-        @type start: str convertable to Timestamp in the format YYYYMMDD. If
+        @type start: str convertible to Timestamp in the format YYYYMMDD. If
             the length is not 8: for backward compatibility to use this as
             'total', it can also be a str (castable to int) or int (positive).
         @param end: Timestamp to end listing at
-        @type end: str convertable to Timestamp in the format YYYYMMDD
+        @type end: str convertible to Timestamp in the format YYYYMMDD
         @return: The generator or None if invalid 'total' value.
         @rtype: LogeventsPageGenerator
         """
@@ -1720,7 +1720,7 @@ def NamespaceFilterPageGenerator(generator, namespaces, site=None):
         type such as NoneType or bool, or more than one namespace
         if the API module does not support multiple namespaces
     """
-    # As site was only required if the namespaces contain strings, dont
+    # As site was only required if the namespaces contain strings, don't
     # attempt to use the config selected site unless the initial attempt
     # at resolving the namespaces fails.
     if not site:
@@ -1890,7 +1890,7 @@ class RegexFilter(object):
     def __filter_match(cls, regex, string, quantifier):
         """Return True if string matches precompiled regex list.
 
-        @param quantifier: a qualifer
+        @param quantifier: a qualifier
         @type quantifier: str of 'all', 'any' or 'none'
         @rtype: bool
         """
@@ -1907,7 +1907,7 @@ class RegexFilter(object):
         if not isinstance(regex, list):
             regex = [regex]
         # Test if regex is already compiled.
-        # We assume that all list componets have the same type
+        # We assume that all list components have the same type
         if isinstance(regex[0], basestring):
             regex = [re.compile(r, flag) for r in regex]
         return regex
@@ -2708,7 +2708,7 @@ class GoogleSearchPageGenerator(object):
         The terms of service as at June 2014 give two conditions that
         may apply to use of search:
 
-            1. Dont access [Google Services] using a method other than
+            1. Don't access [Google Services] using a method other than
                the interface and the instructions that [they] provide.
             2. Don't remove, obscure, or alter any legal notices
                displayed in or along with [Google] Services.

--- a/pywikibot/proofreadpage.py
+++ b/pywikibot/proofreadpage.py
@@ -188,12 +188,12 @@ class ProofreadPage(pywikibot.Page):
 
         E.g. for title 'Page:Popular Science Monthly Volume 1.djvu/12':
         - base = 'Popular Science Monthly Volume 1.djvu'
-        - extenstion = 'djvu'
+        - extension = 'djvu'
         - number = 12
 
         E.g. for title 'Page:Original Waltzing Matilda manuscript.jpg':
         - base = 'Original Waltzing Matilda manuscript.jpg'
-        - extenstion = 'jpg'
+        - extension = 'jpg'
         - number = None
 
         @return: (base, ext, num).

--- a/pywikibot/site.py
+++ b/pywikibot/site.py
@@ -663,7 +663,7 @@ class _InterwikiMap(object):
 
     def __init__(self, site):
         """
-        Create an empty uninitalized interwiki map for the given site.
+        Create an empty uninitialized interwiki map for the given site.
 
         @param site: Given site for which interwiki map is to be created
         @type site: APISite
@@ -875,7 +875,7 @@ class BaseSite(ComparableMixin):
         del new['_pagemutex']
         if '_throttle' in new:
             del new['_throttle']
-        # site cache contains exception information, which cant be pickled
+        # site cache contains exception information, which can't be pickled
         if '_iw_sites' in new:
             del new['_iw_sites']
         return new
@@ -1597,8 +1597,8 @@ class Siteinfo(Container):
         @param expiry: If the cache is older than the expiry it ignores the
             cache and queries the server to get the newest value.
         @type expiry: int (days), L{datetime.timedelta}, False (never)
-        @return: If that property was retrived via this method. Returns None if
-            the key was not in the retreived values.
+        @return: If that property was retrieved via this method. Returns None if
+            the key was not in the retrieved values.
         @rtype: various (the value), bool (if the default value is used)
         """
         if 'general' not in self._cache:
@@ -1640,7 +1640,7 @@ class Siteinfo(Container):
         @type key: str
         @param get_default: Whether to throw an KeyError if the key is invalid.
         @type get_default: bool
-        @param cache: Caches the result interally so that future accesses via
+        @param cache: Caches the result internally so that future accesses via
             this method won't query the server.
         @type cache: bool
         @param expiry: If the cache is older than the expiry it ignores the
@@ -5806,7 +5806,7 @@ class APISite(BaseSite):
         revid = revid or set()
         revision = revision or set()
 
-        # TODO: remove exeception for mw < 1.22
+        # TODO: remove exception for mw < 1.22
         if (revid or revision) and self.mw_version < '1.22':
             raise NotImplementedError(
                 'Support of "revid" parameter\n'

--- a/pywikibot/site_detect.py
+++ b/pywikibot/site_detect.py
@@ -149,7 +149,7 @@ class MWSite(object):
                 try:
                     d = json.loads(d)
                 except ValueError:
-                    # Fallback for old versions which didnt wrap help in json
+                    # Fallback for old versions which didn't wrap help in json
                     d = {'error': {'*': d}}
 
                 self.version = list(filter(

--- a/pywikibot/textlib.py
+++ b/pywikibot/textlib.py
@@ -77,7 +77,7 @@ TEMP_REGEX = DeprecatedRegex(
 
 # The regex below collects nested templates, providing simpler
 # identification of templates used at the top-level of wikitext.
-# It doesnt match {{{1|...}}}, however it also does not match templates
+# It doesn't match {{{1|...}}}, however it also does not match templates
 # with a numerical name. e.g. {{1|..}}. It will correctly match {{{x}} as
 # being {{x}} with leading '{' left in the wikitext.
 # Prefix msg: is not included in the 'name' group, but all others are

--- a/pywikibot/tools/__init__.py
+++ b/pywikibot/tools/__init__.py
@@ -400,7 +400,7 @@ def py2_encode_utf_8(func):
 class classproperty(object):  # noqa: N801
 
     """
-    Descriptor class to accesss a class method as a property.
+    Descriptor class to access a class method as a property.
 
     This class may be used as a decorator::
 
@@ -1176,7 +1176,7 @@ class EmptyDefault(str, Mapping):
     A default for a not existing siteinfo property.
 
     It should be chosen if there is no better default known. It acts like an
-    empty collections, so it can be iterated through it savely if treated as a
+    empty collections, so it can be iterated through it safely if treated as a
     list, tuple, set or dictionary. It is also basically an empty string.
 
     Accessing a value via __getitem__ will result in an combined KeyError and

--- a/pywikibot/tools/djvu.py
+++ b/pywikibot/tools/djvu.py
@@ -336,7 +336,7 @@ class DjVuFile(object):
         # ref page info.
         if n_tot > 2:
             assert self.number_of_images(force=True) == n_tot - 1
-            # cahce cleared above
+            # cache cleared above
             assert self.page_info(new_ref_page) == info_ref_page
         else:
             # If djvu has only one page, FORM:DJVU line in djvudump has no id

--- a/pywikibot/tools/formatter.py
+++ b/pywikibot/tools/formatter.py
@@ -111,7 +111,7 @@ class _ColorFormatter(Formatter):
         Override original `_vformat` to prevent that it changes into `bytes`.
 
         The original `_vformat` is returning `bytes` under certain
-        curcumstances. It happens when the `format_string` is empty, when there
+        circumstances. It happens when the `format_string` is empty, when there
         is no literal text around it or when the field value is not a `unicode`
         already.
 

--- a/pywikibot/userinterfaces/gui.py
+++ b/pywikibot/userinterfaces/gui.py
@@ -447,7 +447,7 @@ class ListBoxWindow(object):
         self.parent.destroy()
 
     def __init__(self, parent=None):
-        """Constuctor."""
+        """Constructor."""
         if parent is None:
             # create a new window
             parent = Tkinter.Tk()

--- a/pywikibot/version.py
+++ b/pywikibot/version.py
@@ -559,7 +559,7 @@ def package_versions(modules=None, builtins=False, standard_lib=None):
             if 'ver' in info:
                 data[name] = info
             else:
-                # Remove the entry from paths, so it isnt processed below
+                # Remove the entry from paths, so it isn't processed below
                 del paths[info['path']]
         else:
             data[name] = info

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ PyMySQL
 # scripts/script_wui.py depends on Lua, which is not available using pip
 # but can be obtained from: https://github.com/bastibe/lunatic-python
 # However, a better fork is: https://github.com/AlereDevices/lunatic-python
-# Also script_wui.py is not currently functional, so it isnt installed here.
+# Also script_wui.py is not currently functional, so it isn't installed here.
 
 # core HTML comparison parser in diff module
 beautifulsoup4

--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -102,7 +102,7 @@ The contents of the package
     +------------------------++--------------------------------------------------------+
     | harvest_template.py    | [IMPROV] Reduce maximum line length to 130              |
     +------------------------+---------------------------------------------------------+
-    | illustrate_wikidata.py | Dont use 'gen' to refer to the generator factory        |
+    | illustrate_wikidata.py | Don't use 'gen' to refer to the generator factory       |
     +------------------------+---------------------------------------------------------+
     | image.py               | This script can be used to change one image to another  |
     |                        | or remove an image entirely.                            |

--- a/scripts/add_text.py
+++ b/scripts/add_text.py
@@ -241,7 +241,7 @@ def main(*args):
     @param args: command line arguments
     @type args: unicode
     """
-    # If none, the var is setted only for check purpose.
+    # If none, the var is set only for check purpose.
     summary = None
     addText = None
     regexSkip = None

--- a/scripts/archivebot.py
+++ b/scripts/archivebot.py
@@ -124,7 +124,7 @@ MW_KEYS = FrozenDict({
     'd': 'days',
     'w': 'weeks',
     'y': 'years',
-    # 'months' and 'minutes' were removed because confusion outweights merit
+    # 'months' and 'minutes' were removed because confusion outweighs merit
 }, 'MW_KEYS is a dict constant')
 
 
@@ -190,7 +190,7 @@ def str2time(string, timestamp=None):
         2w - 2 weeks (14 days)
         1y - 1 year
     @type string: str
-    @param timestamp: a timestamp to calulate a more accurate duration offset
+    @param timestamp: a timestamp to calculate a more accurate duration offset
         used by years
     @type timestamp: datetime.datetime
     @return: the corresponding timedelta object

--- a/scripts/basic.py
+++ b/scripts/basic.py
@@ -18,7 +18,7 @@ The following parameters are supported:
 
 -text:            Use this text to be added; otherwise 'Test' is used
 
--replace:         Dont add text but replace it
+-replace:         Don't add text but replace it
 
 -top              Place additional text on top of the page
 

--- a/scripts/blockpageschecker.py
+++ b/scripts/blockpageschecker.py
@@ -3,7 +3,7 @@
 """
 A bot to remove stale protection templates from pages that are not protected.
 
-Very often sysops block the pages for a setted time but then the forget to
+Very often sysops block the pages for a set time but then the forget to
 remove the warning! This script is useful if you want to remove those useless
 warning left in these pages.
 
@@ -284,7 +284,7 @@ def main(*args):
     if not generator:
         generator = []
         pywikibot.output('Loading categories...')
-        # Define the category if no other generator has been setted
+        # Define the category if no other generator has been set
         for CAT in categories:
             cat = pywikibot.Category(site, CAT)
             # Define the generator
@@ -381,7 +381,7 @@ def main(*args):
                     text, changes = re.subn(TemplateInThePage[1], TNR[1], text)
 
         elif TSP or TU:
-            # implicitely editRestr[0] = 'autoconfirmed', edit-Semi-protection
+            # implicitly editRestr[0] = 'autoconfirmed', edit-Semi-protection
             if TemplateInThePage[0] == 'autoconfirmed-total' or \
                TemplateInThePage[0] == 'unique':
                 msg = 'The page is editable only for the autoconfirmed users'
@@ -448,7 +448,7 @@ def main(*args):
                                                 text)
 
             elif TSMP or TU:
-                # implicitely moveRestr[0] = 'autoconfirmed',
+                # implicitly moveRestr[0] = 'autoconfirmed',
                 # move-semi-protection
                 if TemplateInThePage[0] == 'autoconfirmed-move' or \
                    TemplateInThePage[0] == 'unique':

--- a/scripts/category.py
+++ b/scripts/category.py
@@ -1112,7 +1112,7 @@ class CategoryTidyRobot(Bot, CategoryPreprocess):
             pywikibot.output('Page {} not found.'.format(member.title()))
             return
 
-        # skip initial templates, images and coments for articles.
+        # skip initial templates, images and comments for articles.
         if member.namespace() == member.site.namespaces.MAIN:
             excludes = ('template', 'file', 'comment')
             regexes = textlib._get_regexes(excludes, member.site)

--- a/scripts/checkimages.py
+++ b/scripts/checkimages.py
@@ -469,7 +469,7 @@ duplicates_comment_image = {
     'it': 'Bot: File doppio, da cancellare',
 }
 
-# Regex to detect the template put in the image's decription to find the dupe
+# Regex to detect the template put in the image's description to find the dupe
 duplicatesRegex = {
     'commons': r'\{\{(?:[Tt]emplate:|)(?:[Dd]up(?:licat|)e|[Bb]ad[ _][Nn]ame)'
                r'[|}]',

--- a/scripts/djvutext.py
+++ b/scripts/djvutext.py
@@ -161,7 +161,7 @@ def main(*args):
         pywikibot.bot.suggest_help(missing_parameters=['-index'])
         return False
 
-    # If djvu_path is not a fle, build djvu_path from dir+index.
+    # If djvu_path is not a file, build djvu_path from dir+index.
     djvu_path = os.path.expanduser(djvu_path)
     djvu_path = os.path.abspath(djvu_path)
     if not os.path.exists(djvu_path):

--- a/scripts/editarticle.py
+++ b/scripts/editarticle.py
@@ -79,7 +79,7 @@ class ArticleEditor(object):
             self.page = self.page.getRedirectTarget()
 
     def handle_edit_conflict(self, new):
-        """When an edit conflict occures save the new text to a file."""
+        """When an edit conflict occurs save the new text to a file."""
         fn = os.path.join(tempfile.gettempdir(), self.page.title())
         with open(fn, 'w') as fp:
             fp.write(new)

--- a/scripts/followlive.py
+++ b/scripts/followlive.py
@@ -398,7 +398,7 @@ What is it? """
         self.generator = self.site.newpages()
 
     def show_page_info(self):
-        """Display informations about an article."""
+        """Display information about an article."""
         pywikibot.output('Date:   {info.date}\n'
                          'Length: {info.length} bytes\n'
                          'User:   {info.user.username}'

--- a/scripts/imagecopy.py
+++ b/scripts/imagecopy.py
@@ -296,7 +296,7 @@ class imageTransfer(threading.Thread):
         # Should check if the image actually was uploaded
         if pywikibot.Page(self.image_repo,
                           'Image:' + self.newname).exists():
-            # Get a fresh copy, force to get the page so we dont run into edit
+            # Get a fresh copy, force to get the page so we don't run into edit
             # conflicts
             imtxt = self.imagePage.get(force=True)
 
@@ -548,7 +548,7 @@ def main(*args):
                         skip = True
                 else:
                     while True:
-                        # Do the TkdialogIC to accept/reject and change te name
+                        # Do the TkdialogIC to accept/reject and change the name
                         newname, skip = TkdialogIC(
                             imagepage.title(with_ns=False),
                             imagepage.get(), username,
@@ -576,7 +576,7 @@ def main(*args):
                             pywikibot.output(
                                 'Image already exists, pick another name or '
                                 'skip this image')
-                        # We dont overwrite images, pick another name, go to
+                        # We don't overwrite images, pick another name, go to
                         # the start of the loop
 
             if not skip:

--- a/scripts/imagecopy_self.py
+++ b/scripts/imagecopy_self.py
@@ -493,7 +493,7 @@ class imageFetcher(threading.Thread):
         # Permission
         # Still have to filter out crap like "see below" or "yes"
         if contents['permission']:
-            # Strip of the license temlate if it's in the permission section
+            # Strip of the license template if it's in the permission section
             for (regex, repl) in licenseTemplates[imagepage.site.lang]:
                 contents['permission'] = re.sub(regex, '',
                                                 contents['permission'],
@@ -657,7 +657,7 @@ class userInteraction(threading.Thread):
                 return False
         else:
             while True:
-                # Do the TkdialogICS to accept/reject and change te name
+                # Do the TkdialogICS to accept/reject and change the name
                 fields = TkdialogICS(fields).getnewmetadata()
 
                 if fields.get('skip'):
@@ -674,7 +674,7 @@ class userInteraction(threading.Thread):
                 else:
                     pywikibot.output('Image already exists, pick another name '
                                      'or skip this image')
-                    # We dont overwrite images, pick another name, go to the
+                    # We don't overwrite images, pick another name, go to the
                     # start of the loop
 
         # Put the fields in the queue to be uploaded
@@ -984,7 +984,7 @@ class uploader(threading.Thread):
         """Tagged the imag which has been moved to Commons for deletion."""
         if pywikibot.Page(pywikibot.Site('commons', 'commons'),
                           'File:' + filename).exists():
-            # Get a fresh copy, force to get the page so we dont run into edit
+            # Get a fresh copy, force to get the page so we don't run into edit
             # conflicts
             imtxt = imagepage.get(force=True)
 

--- a/scripts/imagerecat.py
+++ b/scripts/imagerecat.py
@@ -146,7 +146,7 @@ def getCommonshelperCats(imagepage):
              'cl': hint_wiki,
              'w': lang})
     else:
-        # Cant handle other sites atm
+        # Can't handle other sites atm
         return [], [], []
 
     commonsenseRe = re.compile(

--- a/scripts/imageuncat.py
+++ b/scripts/imageuncat.py
@@ -38,7 +38,7 @@ ignoreCategories = ['[[Category:CC-BY-SA-3.0]]',
                     '[[Category:Media lacking a description]]',
                     '[[Category:Self-published work]]']
 
-# Dont bother to put the template on a image with one of these templates
+# Don't bother to put the template on a image with one of these templates
 skipTemplates = ['Delete',
                  'Nocat',
                  'No license',

--- a/scripts/interwiki.py
+++ b/scripts/interwiki.py
@@ -61,7 +61,7 @@ These command-line arguments can be used to specify which pages to work on:
                    against the live wiki is using the warnfile.py
                    script.
 
-Additionaly, these arguments can be used to restrict the bot to certain pages:
+Additionally, these arguments can be used to restrict the bot to certain pages:
 
     -namespace:n   Number or name of namespace to process. The parameter can be
                    used multiple times. It works in combination with all other
@@ -95,7 +95,7 @@ Additionaly, these arguments can be used to restrict the bot to certain pages:
                    like -lack:xx:nn, so that the bot only works on pages with
                    at least nn interwiki links (the default value for nn is 1).
 
-These arguments control miscellanous bot behaviour:
+These arguments control miscellaneous bot behaviour:
 
     -quiet         Use this option to get less output
                    (note: without ending colon)
@@ -104,7 +104,7 @@ These arguments control miscellanous bot behaviour:
                    enables loading pages during saving throtteling and gives a
                    better performance.
                    NOTE: For post-processing it always assumes that saving the
-                   the pages was sucessful.
+                   the pages was successful.
                    (note: without ending colon)
 
     -summary:      Set an additional action summary message for the edit. This
@@ -935,7 +935,7 @@ class Subject(interwiki_graph.Subject):
 
     def addIfNew(self, page, counter, linkingPage):
         """
-        Add the pagelink given to the todo list, if it hasnt been seen yet.
+        Add the pagelink given to the todo list, if it hasn't been seen yet.
 
         If it is added, update the counter accordingly.
 
@@ -1324,7 +1324,7 @@ class Subject(interwiki_graph.Subject):
                 self.conf.note('{} is a page section. Skipping.'.format(page))
                 continue
 
-            # Page exists, isnt a redirect, and is a plain link (no section)
+            # Page exists, isn't a redirect, and is a plain link (no section)
             if self.originPage is None:
                 # the 1st existig page becomes the origin page, if none was
                 # supplied
@@ -2347,7 +2347,7 @@ def botMayEdit(page):
 
 
 def readWarnfile(filename, bot):
-    """Read old interlanguage conficts."""
+    """Read old interlanguage conflicts."""
     import warnfile
     reader = warnfile.WarnfileReader(filename)
     # we won't use removeHints

--- a/scripts/listpages.py
+++ b/scripts/listpages.py
@@ -50,14 +50,14 @@ These parameters are supported to specify which pages titles to print:
 
 -save       Save Page content to a file named as page.title(as_filename=True).
             Directory can be set with -save:dir_name
-            If no dir is specified, current direcory will be used.
+            If no dir is specified, current directory will be used.
 
 -encode     File encoding can be specified with '-encode:name' (name must be
             a valid python encoding: utf-8, etc.).
             If not specified, it defaults to config.textfile_encoding.
 
 -put:       Save the list to the defined page of the wiki. By default it does
-            not overwrite an exisiting page.
+            not overwrite an existing page.
 
 -overwrite  Overwrite the page if it exists. Can only by applied with -put.
 

--- a/scripts/maintenance/cache.py
+++ b/scripts/maintenance/cache.py
@@ -230,7 +230,7 @@ def process_entries(cache_path, func, use_accesstime=None, output_func=None,
     @param use_accesstime: Whether access times should be used.
     @type use_accesstime: bool tristate:
          - None  = detect
-         - False = dont use
+         - False = don't use
          - True  = always use
     """
     if not cache_path:
@@ -255,7 +255,7 @@ def process_entries(cache_path, func, use_accesstime=None, output_func=None,
 
         entry = CacheEntry(cache_dir, filename)
 
-        # Deletion is choosen only, abbreviate this request
+        # Deletion is chosen only, abbreviate this request
         if func is None and output_func is None \
            and action_func == CacheEntry._delete:
             action_func(entry)
@@ -442,12 +442,12 @@ def main():
         # Add tests folders
         cache_paths += [os.path.join('tests', f) for f in folders]
 
-        # Also process the base directory, if it isnt the current directory
+        # Also process the base directory, if it isn't the current directory
         if os.path.abspath(os.getcwd()) != pywikibot.config2.base_dir:
             cache_paths += [
                 os.path.join(pywikibot.config2.base_dir, f) for f in folders]
 
-        # Also process the user home cache, if it isnt the config directory
+        # Also process the user home cache, if it isn't the config directory
         userpath = os.path.expanduser(os.path.join('~', '.pywikibot'))
         if userpath != pywikibot.config2.base_dir:
             cache_paths += [

--- a/scripts/maintenance/make_i18n_dict.py
+++ b/scripts/maintenance/make_i18n_dict.py
@@ -13,7 +13,7 @@ If you have more than one message dictionary, give all these names to the bot:
 >>> bot = i18nBot('<scriptname>', '<msg dict1>', '<msg dict2>', '<msg dict3>')
 
 If you want to rename the message index use keyword arguments. This may be
-mixed with preleading positonal argumens:
+mixed with preleading positonal arguments:
 >>> bot = i18nBot('<scriptname>', '<msg dict1>', the_other_msg='<msg dict2>')
 
 If you have the messages as instance constants you may call the bot as follows:

--- a/scripts/makecat.py
+++ b/scripts/makecat.py
@@ -298,7 +298,7 @@ def main(*args):
 
     # Fetch articles in category, and mark as already checked (seen)
     # If category is empty, ask user if they want to look for pages
-    # in a diferent category.
+    # in a different category.
     articles = list(workingcat.articles(content=True))
     if not articles:
         pywikibot.output('Category {} does not exist or is empty. '

--- a/scripts/misspelling.py
+++ b/scripts/misspelling.py
@@ -42,7 +42,7 @@ if not PY2:
     basestring = (str, )
 
 HELP_MSG = """\n
-mispelling.py does not support site {site}.
+misspelling.py does not support site {site}.
 
 Help Pywikibot team to provide support for your wiki by submitting
 a bug to:

--- a/scripts/noreferences.py
+++ b/scripts/noreferences.py
@@ -652,7 +652,7 @@ class NoReferencesBot(Bot):
             else:
                 break
         pywikibot.output(
-            'Found no section that can be preceeded by a new references '
+            'Found no section that can be preceded by a new references '
             'section.\nPlacing it before interwiki links, categories, and '
             'bottom templates.')
         index = len(tmpText)

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -166,7 +166,7 @@ class PatrolBot(SingleSiteBot):
             self.whitelist_ts = whitelist_page.editTime()
             self.whitelist_load_ts = time.time()
         except Exception as e:
-            # cascade if there isnt a whitelist to fallback on
+            # cascade if there isn't a whitelist to fallback on
             if not self.whitelist:
                 raise
             pywikibot.error('{0}'.format(e))
@@ -221,7 +221,7 @@ class PatrolBot(SingleSiteBot):
                 obj = pywikibot.Link(node.title, self.site)
                 if obj.namespace == -1:
                     # the parser accepts 'special:prefixindex/' as a wildcard
-                    # this allows a prefix that doesnt match an existing page
+                    # this allows a prefix that doesn't match an existing page
                     # to be a blue link, and can be clicked to see what pages
                     # will be included in the whitelist
                     name, sep, prefix = obj.title.partition('/')
@@ -299,7 +299,7 @@ class PatrolBot(SingleSiteBot):
         try:
             # page: title, date, username, comment, loginfo, rcid, token
             username = page['user']
-            # when the feed isnt from the API, it used to contain
+            # when the feed isn't from the API, it used to contain
             # '(not yet written)' or '(page does not exist)' when it was
             # a redlink
             rcid = page['rcid']

--- a/scripts/replicate_wiki.py
+++ b/scripts/replicate_wiki.py
@@ -189,7 +189,7 @@ class SyncSites(object):
             sync_overview_page.save(self.put_message(site))
 
     def put_message(self, site):
-        """Return synchonization message."""
+        """Return synchronization message."""
         return ('{0} replicate_wiki.py synchronization from {1}'
                 .format(site.user(), str(self.original)))
 

--- a/scripts/script_wui.py
+++ b/scripts/script_wui.py
@@ -160,7 +160,7 @@ class ScriptWUIBot(pywikibot.botirc.IRCBot):
             try:
                 self.refs[item].get(force=True)   # load all page contents
             except pywikibot.NoPage:
-                pywikibot.error("The configuation page {0} doesn't exists"
+                pywikibot.error("The configuration page {0} doesn't exists"
                                 .format(self.refs[item].title(as_link=True)))
                 raise
         # init background timer
@@ -256,7 +256,7 @@ def main_script(page, rev=None, params=NotImplemented):
     sys.stdout = buffer
     sys.stderr = buffer
 
-    # all output to logging and stdout/stderr is catched BUT NOT lua output (!)
+    # all output to logging and stdout/stderr is caught BUT NOT lua output (!)
     if rev is None:
         code = page.get()               # shell; "on demand"
     else:

--- a/scripts/solve_disambiguation.py
+++ b/scripts/solve_disambiguation.py
@@ -944,7 +944,7 @@ class DisambiguationRobot(SingleSiteBot):
                     assert self.dn_template_str
                     # small chunk of text to search
                     search_text = text[m.end():m.end() + context]
-                    # figure out where the link (and sentance) ends, put note
+                    # figure out where the link (and sentence) ends, put note
                     # there
                     end_of_word_match = re.search(r'\s', search_text)
                     if end_of_word_match:

--- a/scripts/table2wiki.py
+++ b/scripts/table2wiki.py
@@ -277,7 +277,7 @@ class Table2WikiRobot(SingleSiteBot, ExistingPageBot, NoRedirectPageBot):
             r'\r\n!\1\2', new_table)
 
         ##################
-        # kills indention within tables. Be warned, it might seldom bring
+        # kills indentation within tables. Be warned, it might seldom bring
         # bad results.
         # True by default. Set 'deIndentTables = False' in user-config.py
         if config.deIndentTables:
@@ -327,7 +327,7 @@ class Table2WikiRobot(SingleSiteBot, ExistingPageBot, NoRedirectPageBot):
         while num != 0:
             # The same for header and cell tags ( ! or | ), but for these tags
             # the attribute part is finished by a | character. We don't want to
-            # change cell contents which accidentially contain an equal sign.
+            # change cell contents which accidentally contain an equal sign.
             # Group 1 and 2 are anologously to the previous regular expression,
             # group 3 are the remaining attribute key - value pairs.
             new_table, num = re.subn(

--- a/scripts/template.py
+++ b/scripts/template.py
@@ -39,7 +39,7 @@ Command line options:
 
 -timestamp:  (With -onlyuser or -skipuser). Only check for a user where his
              edit is not older than the given timestamp. Timestamp must be
-             writen in MediaWiki timestamp format which is "%Y%m%d%H%M%S".
+             written in MediaWiki timestamp format which is "%Y%m%d%H%M%S".
              If this parameter is missed, all edits are checked but this is
              restricted to the last 100 edits.
 

--- a/scripts/welcome.py
+++ b/scripts/welcome.py
@@ -448,7 +448,7 @@ _MSGS = {
 
 class FilenameNotSet(pywikibot.Error):
 
-    """An exception indicating that a signature filename was not specifed."""
+    """An exception indicating that a signature filename was not specified."""
 
 
 class Global(object):
@@ -574,7 +574,7 @@ class WelcomeBot(object):
                     pywikibot.output("The whitelist's page doesn't exist!")
             else:
                 showStatus(4)
-                pywikibot.warning("The whitelist hasn't been setted!")
+                pywikibot.warning("The whitelist hasn't been set!")
 
             # Join the whitelist words.
             self._whitelist = list_white + whitelist_default

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ if sys.platform.startswith('linux'):
 # The main pywin32 repository contains a Python 2 only setup.py with a small
 # wrapper setup3.py for Python 3.
 # http://pywin32.hg.sourceforge.net:8000/hgroot/pywin32/pywin32
-# The main pywinauto repository doesnt support Python 3.
+# The main pywinauto repository doesn't support Python 3.
 # The repositories used below have a Python 3 compliant setup.py
 dependency_links = [
     'git+https://github.com/AlereDevices/lunatic-python.git#egg='
@@ -135,12 +135,12 @@ else:
 # to set the console font and copy and paste, achieved using pywinauto
 # which depends on pywin32.
 # These tests may be disabled because pywin32 depends on VC++, is time
-# comsuming to build, and the console window cant be accessed during appveyor
+# consuming to build, and the console window can't be accessed during appveyor
 # builds.
 # Microsoft makes available a compiler for Python 2.7
 # http://www.microsoft.com/en-au/download/details.aspx?id=44266
 if os.name == 'nt' and os.environ.get('PYSETUP_TEST_NO_UI', '0') != '1':
-    # which isnt provided on pypi.
+    # which isn't provided on pypi.
     test_deps += ['pywin32', 'pywinauto>=0.4.0']
 
 extra_deps.update(script_deps)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -252,7 +252,7 @@ CachedRequest._get_cache_dir = classmethod(
 
 
 # Travis-CI builds are set to retry twice, which aims to reduce the number
-# of 'red' builds caused by intermittant server problems, while also avoiding
+# of 'red' builds caused by intermittent server problems, while also avoiding
 # the builds taking a long time due to retries.
 # The following allows builds to retry twice, but higher default values are
 # overridden here to restrict retries to only 1, so developer builds fail more
@@ -299,7 +299,7 @@ class TestRequest(CachedRequest):
             return False
 
         # tokens need careful management in the cache
-        # and cant be aggressively cached.
+        # and can't be aggressively cached.
         # FIXME: remove once 'badtoken' is reliably handled in api.py
         if 'intoken' in self._uniquedescriptionstr():
             self._data = None

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -636,7 +636,7 @@ class TestDryPageGenerator(TestCase):
 
     def test_initial_limit(self):
         """Test the default limit."""
-        self.assertIsNone(self.gen.limit)  # limit is initally None
+        self.assertIsNone(self.gen.limit)  # limit is initially None
 
     def test_set_limit_as_number(self):
         """Test setting the limit using an int."""

--- a/tests/aspects.py
+++ b/tests/aspects.py
@@ -284,7 +284,7 @@ class TestCaseBase(unittest.TestCase):
             a context manager like L{assertRaises}.
         @type callable_obj: callable
         @param args: The positional arguments forwarded to the callable object.
-        @param kwargs: The keyword arguments forwared to the callable object.
+        @param kwargs: The keyword arguments forwarded to the callable object.
         @return: Context manager if callable_obj is None and None otherwise.
         @rtype: None or context manager
         """
@@ -669,7 +669,7 @@ class RequireUserMixin(TestCaseBase):
         """Login to all sites."""
         sysop = hasattr(self, 'sysop') and self.sysop
 
-        # There may be many sites, and setUp doesnt know
+        # There may be many sites, and setUp doesn't know
         # which site is to be tested; ensure they are all
         # logged in.
         for site in self.sites.values():
@@ -1421,7 +1421,7 @@ class PwbTestCase(TestCase):
     The flag 'pwb' is used by the TestCase metaclass to check that a test site
     is set declared in the class properties, or that 'site = False' is added
     to the class properties in the unlikely scenario that the test case
-    uses pwb in a way that doesnt use a site.
+    uses pwb in a way that doesn't use a site.
 
     If a test class is marked as 'site = False', the metaclass will also check
     that the 'net' flag is explicitly set.

--- a/tests/basepage_tests.py
+++ b/tests/basepage_tests.py
@@ -69,7 +69,7 @@ class BasePageLoadRevisionsCachingTestBase(BasePageTestBase):
         self.assertFalse(hasattr(page, '_text'))
         self.assertIsNotNone(page._latest_cached_revision())
 
-        # Verify that calling .text doesnt call loadrevisions again
+        # Verify that calling .text doesn't call loadrevisions again
         loadrevisions = self.site.loadrevisions
         try:
             self.site.loadrevisions = None

--- a/tests/bot_tests.py
+++ b/tests/bot_tests.py
@@ -77,7 +77,7 @@ class FakeSaveBotTestCase(TestCase):
         self._old_counter = self._bot._save_counter
 
     def setUp(self):
-        """Set up test by reseting the counters."""
+        """Set up test by resetting the counters."""
         super(FakeSaveBotTestCase, self).setUp()
         self.assert_saves = getattr(self, 'default_assert_saves', 1)
         self.save_called = 0

--- a/tests/diff_tests.py
+++ b/tests/diff_tests.py
@@ -207,7 +207,7 @@ class TestCherryPick(TestCase):
                               '\x03{lightgreen}+ w\n\x03{default}')
 
     def check_headers(self, mock):
-        """Check if all headers were added to ouput."""
+        """Check if all headers were added to output."""
         for header in self.headers:
             mock.assert_any_call(self.header_base.format(header))
 
@@ -234,7 +234,7 @@ class TestCherryPick(TestCase):
     @patch('pywikibot.userinterfaces.terminal_interface_base.UI.input',
            return_value='q')
     def test_quit(self, input, mock):
-        """Check output of cherry_pick if quitted."""
+        """Check output of cherry_pick if quit."""
         self.assertEqual(cherry_pick(self.oldtext, self.newtext), self.oldtext)
         self.check_headers(mock)
         mock.assert_any_call(self.diff_message)
@@ -259,7 +259,7 @@ class TestCherryPick(TestCase):
     def test_by_letter_quit(self, input, mock):
         """Check cherry_pick output.
 
-        If by_letter diff is enabled and quitted during review.
+        If by_letter diff is enabled and quit during review.
         """
         self.assertEqual(cherry_pick(self.oldtext, self.newtext,
                                      by_letter=True), self.oldtext)

--- a/tests/dry_api_tests.py
+++ b/tests/dry_api_tests.py
@@ -58,7 +58,7 @@ class DryCachedRequestTests(SiteAttributeTestCase):
         self.diffsite = CachedRequest(
             expiry=1, site=self.altsite,
             parameters={'action': 'query', 'meta': 'userinfo'})
-        # When using ** the paramters are still unicode
+        # When using ** the parameters are still unicode
         with suppress_warnings('Instead of using kwargs ', DeprecationWarning):
             self.deprecated_explicit = CachedRequest(
                 expiry=1, site=self.basesite, action='query', meta='userinfo')

--- a/tests/file_tests.py
+++ b/tests/file_tests.py
@@ -287,7 +287,7 @@ class TestDeprecatedFilePage(DeprecationTestCase):
 
 class TestFilePageDownload(TestCase):
 
-    """Test dowload fo FilePage to local file."""
+    """Test download of FilePage to local file."""
 
     family = 'commons'
     code = 'commons'

--- a/tests/generate_family_files_tests.py
+++ b/tests/generate_family_files_tests.py
@@ -44,7 +44,7 @@ class TestGenerateFamilyFiles(DefaultSiteTestCase):
             url=self.site.base_url(''), name='gff-test', dointerwiki='y')
 
     def test_initial_attributes(self):
-        """Test inital FamilyFileGenerator attributes."""
+        """Test initial FamilyFileGenerator attributes."""
         self.assertEqual(self.generator_instance.base_url,
                          self.site.base_url(''))
         self.assertEqual(self.generator_instance.name, 'gff-test')

--- a/tests/i18n_tests.py
+++ b/tests/i18n_tests.py
@@ -133,7 +133,7 @@ class TWNTestCaseBase(TWNSetMessagePackageBase):
                             .format(cls.__name__))
         # The call to set_messages_package below exists only to confirm
         # that the package exists and messages are available, so
-        # that tests can be skipped if the i18n data doesnt exist.
+        # that tests can be skipped if the i18n data doesn't exist.
         cls.orig_messages_package_name = i18n._messages_package_name
         i18n.set_messages_package(cls.message_package)
         has_messages = i18n.messages_available()
@@ -390,7 +390,7 @@ class MissingPackageTestCase(TWNSetMessagePackageBase,
                              UserInterfaceLangTestCase,
                              DefaultSiteTestCase):
 
-    """Test misssing messages package."""
+    """Test missing messages package."""
 
     message_package = 'scripts.foobar.i18n'
 

--- a/tests/interwikidata_tests.py
+++ b/tests/interwikidata_tests.py
@@ -62,7 +62,7 @@ class TestInterwikidataBot(SiteAttributeTestCase):
         page = pywikibot.Page(self.en, 'User:Ladsgroup')
         text = page.get()
 
-        # The page looks as excpected.
+        # The page looks as expected.
         self.assertEqual(len(page.langlinks()), 1)
         iw_link = page.langlinks()[0]
         self.assertIsInstance(iw_link, Link)

--- a/tests/link_tests.py
+++ b/tests/link_tests.py
@@ -612,7 +612,7 @@ class TestFullyQualifiedOneSiteFamilyExplicitLinkParser(LinkTestCase):
         self.assertEqual(link.namespace, 1)
 
 
-# ---- Tests of a Link without colons, which shouldnt be interwikis, follow.
+# ---- Tests of a Link without colons, which shouldn't be interwikis, follow.
 
 
 class TestPartiallyQualifiedImplicitLinkSameSiteParser(LinkTestCase):

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -637,7 +637,7 @@ class TestPageDeprecation(DefaultSiteTestCase, DeprecationTestCase):
 
 class TestPageBaseUnicode(DefaultDrySiteTestCase):
 
-    """Base class for tests requring a page using a unicode title."""
+    """Base class for tests requiring a page using a unicode title."""
 
     @classmethod
     def setUpClass(cls):

--- a/tests/pagegenerators_tests.py
+++ b/tests/pagegenerators_tests.py
@@ -877,7 +877,7 @@ class TestFactoryGenerator(DefaultSiteTestCase):
     def test_regexfilter_default(self):
         """Test allpages generator with titleregex filter."""
         gf = pagegenerators.GeneratorFactory()
-        # Matches titles with the same two or more continous characters
+        # Matches titles with the same two or more continuous characters
         self.assertTrue(gf.handleArg('-start'))
         self.assertTrue(gf.handleArg('-titleregex:(.)\\1+'))
         gf.handleArg('-limit:10')

--- a/tests/pwb_tests.py
+++ b/tests/pwb_tests.py
@@ -33,7 +33,7 @@ class TestPwb(PwbTestCase):
 
     # site must be explicitly set for pwb tests. This test does not require
     # network access, because tests/pwb/print_locals.py does not use
-    # handle_args, etc. so version.py doesnt talk on the network.
+    # handle_args, etc. so version.py doesn't talk on the network.
     site = False
     net = False
 

--- a/tests/reflinks_tests.py
+++ b/tests/reflinks_tests.py
@@ -126,7 +126,7 @@ class TestReferencesBotConstructor(ScriptMainTestCase):
     """
     Test reflinks with run() removed.
 
-    These tests cant verify the order of the pages in the XML
+    These tests can't verify the order of the pages in the XML
     as the constructor is given a preloading generator.
     See APISite.preloadpages for details.
     """

--- a/tests/script_tests.py
+++ b/tests/script_tests.py
@@ -24,7 +24,7 @@ archive_path = join_root_path('scripts', 'archive')
 # These dependencies are not always the package name which is in setup.py.
 # e.g. 'PIL.ImageTk' is a object provided by several different pypi packages,
 # and setup.py requests that 'Pillow' is installed to provide 'PIL.ImageTk'.
-# Here, it doesnt matter which pypi package was requested and installed.
+# Here, it doesn't matter which pypi package was requested and installed.
 # Here, the name given to the module which will be imported is required.
 script_deps = {
     'script_wui': ['crontab', 'lua'],
@@ -151,7 +151,7 @@ no_args_expected_results = {
     'unusedfiles': ('Working on', None),
     'watchlist': 'Retrieving watchlist',
 
-    # The following auto-run and typically cant be validated,
+    # The following auto-run and typically can't be validated,
     # however these strings are very likely to exist within
     # the timeout of 5 seconds.
     'revertbot': 'Fetching new batch of contributions',
@@ -310,7 +310,7 @@ class TestScriptMeta(MetaTestCaseClass):
                                  result['stderr'])
                 self.assertNotIn('deprecated', result['stderr'].lower())
 
-                # If stdout doesnt include global help..
+                # If stdout doesn't include global help..
                 if global_args not in result['stdout']:
                     # Specifically look for deprecated
                     self.assertNotIn('deprecated', result['stdout'].lower())

--- a/tests/site_tests.py
+++ b/tests/site_tests.py
@@ -3570,7 +3570,7 @@ class TestProductionAndTestSite(AlteredDefaultSiteTestCase):
         self.assertEqual(site2.hostname(), 'test.wikidata.org')
         self.assertEqual(site2.code, 'test')
 
-        # Languages cant be used due to T71255
+        # Languages can't be used due to T71255
         self.assertRaises(pywikibot.UnknownSite,
                           pywikibot.Site, 'en', 'wikidata')
 

--- a/tests/textlib_tests.py
+++ b/tests/textlib_tests.py
@@ -601,7 +601,7 @@ class TestTemplateParams(TestCase):
                                              ('2', 'c}}}'),
                                              ('3', 'd')]))])
 
-        # Safe fallback to handle arbitary template levels
+        # Safe fallback to handle arbitrary template levels
         # by merging top level templates together.
         # i.e. 'b' is not recognised as a template, and 'foo' is also
         # consumed as part of 'a'.

--- a/tests/timestamp_tests.py
+++ b/tests/timestamp_tests.py
@@ -126,7 +126,7 @@ class TestTimestamp(TestCase):
         self.assertIs(t3, NotImplemented)
 
     def test_sub_timedelta(self):
-        """Test substracting a timedelta from a Timestamp."""
+        """Test subtracting a timedelta from a Timestamp."""
         t1 = Timestamp.utcnow()
         t2 = t1 - datetime.timedelta(days=1)
         if t1.month != t2.month:

--- a/tests/ui_tests.py
+++ b/tests/ui_tests.py
@@ -765,14 +765,14 @@ class FakeUITest(TestCase):
         self.assertEqual(self._getvalue(), self.expected)
 
     def test_stack_with_pop_color(self):
-        """Test using stacked colors and just poping the latest color."""
+        """Test using stacked colors and just popping the latest color."""
         self._colors = (('red', 6), ('yellow', 6), ('red', 3), ('default', 1))
         self.ui_obj._print('Hello \03{red}world \03{yellow}you\03{previous}!',
                            self.stream)
         self.assertEqual(self._getvalue(), self.expected)
 
     def test_stack_implicit_color(self):
-        """Test using stacked colors without poping any."""
+        """Test using stacked colors without popping any."""
         self._colors = (('red', 6), ('yellow', 6), ('default', 4))
         self.ui_obj._print('Hello \03{red}world \03{yellow}you!', self.stream)
         self.assertEqual(self._getvalue(), self.expected)

--- a/tests/wikibase_tests.py
+++ b/tests/wikibase_tests.py
@@ -987,7 +987,7 @@ class TestItemLoad(WikidataTestCase):
         self.assertEqual(item.title(), 'Q5296')
 
         # This del has no effect on the test; it is here to demonstrate that
-        # it doesnt help to clear this piece of saved state.
+        # it doesn't help to clear this piece of saved state.
         del item._content
         # The labels are not updated; assertion showing undesirable behaviour:
         self.assertEqual(item.labels['en'], 'New York City')
@@ -1176,7 +1176,7 @@ class TestItemLoad(WikidataTestCase):
                     with self.assertRaisesRegex(pywikibot.NoPage, regex):
                         getattr(item, method)()
 
-                # The invocation above of a fetching method shouldnt change
+                # The invocation above of a fetching method shouldn't change
                 # the local item, but it does! The title changes to '-1'.
                 #
                 # However when identifying the item for 'en:Test page'

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,7 @@ deps =
 # P103: other string does contain unindexed parameters
 # W503: line break before binary operator; against current PEP 8 recommendation
 
-# Errors occured after upgrade to pydocstyle 2.0.0 (T164142)
+# Errors occurred after upgrade to pydocstyle 2.0.0 (T164142)
 # D401: First line should be in imperative mood; try rephrasing
 # D412: No blank lines allowed between a section header and its content
 # D413: Missing blank line after last section


### PR DESCRIPTION
Typos that are user and non-user facing. 

Found via `codespell -q 3 -L uint,ans,ned,januar,iff,ue,als,redict,errror,aline,ba,stati,ang,alle,modell,archiv`
