### PR TITLE
remove dewiki archive template from edit restrictions

### DIFF
--- a/pywikibot/families/wikipedia_family.py
+++ b/pywikibot/families/wikipedia_family.py
@@ -219,7 +219,6 @@ class Family(family.SubdomainFamily, family.WikimediaFamily):
         'cs': ('Archiv', 'Archiv Wikipedie', 'Archiv diskuse',
                'Archivace start', 'Posloupnost archivů',
                'Rfa-archiv-start', 'Rfc-archiv-start',),
-        'de': ('Archiv',),
     }
 
     def get_known_families(self, site):


### PR DESCRIPTION
There are a lot of possible reasons for a non-archive bot to change an archive page. The current setup makes it unnecessarily difficult to do this. In case you want to avoid editing archive pages you have to search for the templates anyway since the current list is incomplete.