### PR TITLE
Replace "-" with " " when comparing titles

### DIFF
--- a/pywikibot/site.py
+++ b/pywikibot/site.py
@@ -1200,8 +1200,8 @@ class BaseSite(ComparableMixin):
             return True
         # Replace underscores with spaces and multiple combinations of them
         # with only one space
-        title1 = re.sub(r'[_ ]+', ' ', title1)
-        title2 = re.sub(r'[_ ]+', ' ', title2)
+        title1 = re.sub(r'[_\- ]+', ' ', title1)
+        title2 = re.sub(r'[_\- ]+', ' ', title2)
         if title1 == title2:
             return True
         default_ns = self.namespaces[0]


### PR DESCRIPTION
`BaseSite.sametitle` has been giving me trouble as I've been working with (wikiHow)[www.wikihow.com]. Working with the article https://www.wikihow.com/Be-Cyber-Goth, for example, the titles `"Be-Cyber-Goth"` and `"Be Cyber Goth"` are compared and are judged not to be equal. This PR replaces `"-"` with `" "` (which is also how `"_"` is handled), which I think is the correct behavior. Please let me know if you'd like more information.