### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pywikibot/tools/__init__.py
+++ b/pywikibot/tools/__init__.py
@@ -225,7 +225,7 @@ class SizedKeyCollection(Container, Iterable, Sized):
 
     """Structure to hold values where the key is given by the value itself.
 
-    A stucture like a defaultdict but the key is given by the value
+    A structure like a defaultdict but the key is given by the value
     itselfvand cannot be assigned directly. It returns the number of all
     items with len() but not the number of keys.
 

--- a/scripts/checkimages.py
+++ b/scripts/checkimages.py
@@ -24,7 +24,7 @@ This script understands the following command-line arguments:
 -duplicatesreport   Report the duplicates in a log *AND* put the template in
                     the images.
 
--maxusernotify      Maximum nofitications added to a user talk page in a single
+-maxusernotify      Maximum notifications added to a user talk page in a single
                     check, to avoid email spamming.
 
 -sendemail          Send an email after tagging.

--- a/scripts/interwiki.py
+++ b/scripts/interwiki.py
@@ -92,7 +92,7 @@ These arguments control miscellaneous bot behaviour:
                    (note: without ending colon)
 
     -async         Put page on queue to be saved to wiki asynchronously. This
-                   enables loading pages during saving throtteling and gives a
+                   enables loading pages during saving throttling and gives a
                    better performance.
                    NOTE: For post-processing it always assumes that saving the
                    the pages was successful.


### PR DESCRIPTION
There are small typos in:
- pywikibot/tools/__init__.py
- scripts/checkimages.py
- scripts/interwiki.py

Fixes:
- Should read `throttling` rather than `throtteling`.
- Should read `structure` rather than `stucture`.
- Should read `notifications` rather than `nofitications`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md