### PR TITLE
Retrieve token from response

### DIFF
--- a/pywikibot/login.py
+++ b/pywikibot/login.py
@@ -427,7 +427,7 @@ class ClientLoginManager(LoginManager):
                     self.site.family)
                 self.site.tokens.clear()
                 login_request[
-                    self.keyword('token')] = self.site.tokens['login']
+                    self.keyword('token')] = response['token']
                 continue
 
             if status == 'UI':  # pragma: no cover


### PR DESCRIPTION
In the case where the response status is NeedToken, the needed token is in the response. self.site.tokens is an empty dict at this point. This correction allows a login to correctly proceed. Tested with a private wiki running 1.37.4 using a bot login.