### PR TITLE
1105275: Re -  Fix: Implement ISBN retrieval and handle missing data

### DIFF
--- a/scripts/create_isbn_edition.py
+++ b/scripts/create_isbn_edition.py
@@ -864,6 +864,10 @@ def amend_isbn_edition(isbn_number: str) -> int:
 
     # Some digital library services raise failure
     try:
+
+        # Log the current digital library being queried
+        pywikibot.info(f'Querying metadata using service: {booklib}')
+
         # Get ISBN basic data
         isbn_data = isbnlib.meta(isbn_number, service=booklib)
         # {


### PR DESCRIPTION
This request improves the clarity of the current implementation by explicitly logging which digital library service (`goob` for Google Books or `openl` for Open Library) is being queried during the ISBN metadata retrieval process. 

While the `isbnlib.meta` function already retrieves data from the specified service, this enhancement adds a log message to make it clear which service is being used at runtime. This will help avoid any confusion and improve debugging by showing the active service.

### Changes:
- Added a log statement to display the service (`goob` or `openl`) being used when querying ISBN metadata.

This change does not affect the functionality, but enhances visibility into the service selection for debugging and clarity.
